### PR TITLE
Fix chrome installation process and add proper logging.

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -5,5 +5,5 @@ Write-Host "[+] Downloading + Installing chrome rdp"
 & {$P = $env:TEMP + '\chromeremotedesktophost.msi'; Invoke-WebRequest 'https://dl.google.com/edgedl/chrome-remote-desktop/chromeremotedesktophost.msi' -OutFile $P; Start-Process $P -Wait; Remove-Item $P}
 Write-Host "[+] Done."
 Write-Host "[+] Downloading + Installing chrome"
-& {$P = $env:TEMP + '\chrome_installer.exe'; Invoke-WebRequest 'https://dl.google.com/chrome/install/latest/chrome_installer.exe' -OutFile $P; Start-Process -FilePath $P -Args '/install' -Verb RunAs -Wait; Remove-Item $P}
+& {$P = $env:TEMP + '\chrome_installer.exe'; Invoke-WebRequest 'https://dl.google.com/chrome/install/latest/chrome_installer.exe' -OutFile $P; Start-Process -FilePath $P -Args '/silent /install' -Verb RunAs -Wait; Remove-Item $P}
 Write-Host "[+] Done."

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,3 +1,6 @@
+Write-Host "Setting network profile"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+Write-Host "Downloading chrome rdp"
 & {$P = $env:TEMP + '\chromeremotedesktophost.msi'; Invoke-WebRequest 'https://dl.google.com/edgedl/chrome-remote-desktop/chromeremotedesktophost.msi' -OutFile $P; Start-Process $P -Wait; Remove-Item $P}
+Write-Host "Installing chrome"
 & {$P = $env:TEMP + '\chrome_installer.exe'; Invoke-WebRequest 'https://dl.google.com/chrome/install/latest/chrome_installer.exe' -OutFile $P; Start-Process -FilePath $P -Args '/install' -Verb RunAs -Wait; Remove-Item $P}

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,6 +1,9 @@
-Write-Host "Setting network profile"
+Write-Host "[+] Setting network profile"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
-Write-Host "Downloading chrome rdp"
+Write-Host "[+] Done."
+Write-Host "[+] Downloading + Installing chrome rdp"
 & {$P = $env:TEMP + '\chromeremotedesktophost.msi'; Invoke-WebRequest 'https://dl.google.com/edgedl/chrome-remote-desktop/chromeremotedesktophost.msi' -OutFile $P; Start-Process $P -Wait; Remove-Item $P}
-Write-Host "Installing chrome"
+Write-Host "[+] Done."
+Write-Host "[+] Downloading + Installing chrome"
 & {$P = $env:TEMP + '\chrome_installer.exe'; Invoke-WebRequest 'https://dl.google.com/chrome/install/latest/chrome_installer.exe' -OutFile $P; Start-Process -FilePath $P -Args '/install' -Verb RunAs -Wait; Remove-Item $P}
+Write-Host "[+] Done."


### PR DESCRIPTION
1. The chrome installation process is broken because the `/silent` switch isn't used and result's in popup boxes which hang the script for eternity.
2. Added proper logging so that you can know the process of `setup.ps1`.